### PR TITLE
fix flaky test in LogUtilTest.groovy

### DIFF
--- a/parsec-logging/src/test/groovy/com/yahoo/parsec/logging/LogUtilTest.groovy
+++ b/parsec-logging/src/test/groovy/com/yahoo/parsec/logging/LogUtilTest.groovy
@@ -41,7 +41,7 @@ class LogUtilTest extends Specification {
         def result = LogUtil.generateLog(null, null, null, new SimpleDataObject("key1", "value1"))
 
         then:
-        result.matches(/.* timestamp=".+", log_data=\{"key":"key1","value":"value1"\}/)
+        result.matches(/.* timestamp=".+", log_data=\{"key":"key1","value":"value1"\}/) || result.matches(/.* timestamp=".+", log_data=\{"value":"value1","key":"key1"\}/)
     }
 
     def "test generateLog with quote values should return slashed quoted values"() {


### PR DESCRIPTION
## **Problem**
This PR aims to fix the flaky test: [com.yahoo.parsec.logging.LogUtilTest."test generateLog with custom data object should return info contain custom json data"](https://github.com/KiruthikaJanakiraman/parsec-libraries/blob/142bc4c95a8ca7b8c82f7f95d8144cb6d4bc2096/parsec-logging/src/test/groovy/com/yahoo/parsec/logging/LogUtilTest.groovy#L39-L45)


https://github.com/KiruthikaJanakiraman/parsec-libraries/blob/142bc4c95a8ca7b8c82f7f95d8144cb6d4bc2096/parsec-logging/src/test/groovy/com/yahoo/parsec/logging/LogUtilTest.groovy#L40-L44
The above check fails as the order of the items in `log_data` varies upon non-determintic shuffling.

I found and confirmed the flaky behaviour of the test using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

## **Solution**
This PR fixes the test by checking for both possibilities of `log_data`.
https://github.com/KiruthikaJanakiraman/parsec-libraries/blob/bec72f01c3b461f6959865160dfbf6e70212e138/parsec-logging/src/test/groovy/com/yahoo/parsec/logging/LogUtilTest.groovy#L44

## **Steps to reproduce**
The following command can be used to reproduce the assertion errors and verify the fix.

**Integrate NonDex:**

**Add the following snippet to the top of the build.gradle in $PROJ_DIR:**
```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

**Append to build.gradle in $PROJ_DIR:**
```
apply plugin: 'edu.illinois.nondex'
```

**Execute Test with Gradle:**
```
./gradlew test --info parsec-logging:test --tests=com.yahoo.parsec.logging.LogUtilTest."test generateLog with custom data object should return info contain custom json data"
```

**Run NonDex:**
```
./gradlew test --info parsec-logging:nondexTest --tests=com.yahoo.parsec.logging.LogUtilTest."test generateLog with custom data object should return info contain custom json data" --nondexRuns=50
```

**Test Environment:**
```
Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.